### PR TITLE
Stop using nunit3 which is not supported by Xamarin.UITest yet

### DIFF
--- a/step.rb
+++ b/step.rb
@@ -65,12 +65,18 @@ def run_unit_test!(dll_path, test_to_run)
   nunit_path = ENV['NUNIT_PATH']
   fail_with_message('No NUNIT_PATH environment specified') unless nunit_path
 
-  nunit_console_path = File.join(nunit_path, 'nunit-console.exe')
+  nunit_console_path = File.join(nunit_path, 'nunit3-console.exe')
+  nunit_run_option="-test"
+  unless File.exist?(nunit_console_path)
+    # Nunit2 support
+    nunit_console_path = File.join(nunit_path, 'nunit-console.exe')
+    nunit_run_option="run"
+  end
 
   params = []
   params << @mono
   params << nunit_console_path
-  params << "-run=\"#{test_to_run}\"" unless test_to_run.to_s == ''
+  params << "-#{nunit_run_option}=\"#{test_to_run}\"" unless test_to_run.to_s == ''
   params << dll_path
 
   command = params.join(' ')

--- a/step.rb
+++ b/step.rb
@@ -70,7 +70,7 @@ def run_unit_test!(dll_path, test_to_run)
   params = []
   params << @mono
   params << nunit_console_path
-  params << "--test=\"#{test_to_run}\"" unless test_to_run.to_s == ''
+  params << "-run=\"#{test_to_run}\"" unless test_to_run.to_s == ''
   params << dll_path
 
   command = params.join(' ')

--- a/step.rb
+++ b/step.rb
@@ -65,7 +65,7 @@ def run_unit_test!(dll_path, test_to_run)
   nunit_path = ENV['NUNIT_PATH']
   fail_with_message('No NUNIT_PATH environment specified') unless nunit_path
 
-  nunit_console_path = File.join(nunit_path, 'nunit3-console.exe')
+  nunit_console_path = File.join(nunit_path, 'nunit-console.exe')
 
   params = []
   params << @mono


### PR DESCRIPTION
This PR ensures that we can run Xamarin.UITest tests which require nunit2 not nunit3. 

Note: this will require bitrise installing nunit2 (2.x) (it should pick the version based on the users nunit version in the nuget packages). Alternatively just 2.6.4 (latest 2.x).

NUNIT_PATH will need to be set appropriately for this to work locally too
